### PR TITLE
Fix express type errors and missing html file

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -57,10 +57,10 @@ app.use(cors({
 }))
 
 // Compression
-app.use(compression())
+app.use(compression() as unknown as express.RequestHandler)
 
 // Rate limiting
-app.use('/api', limiter)
+app.use('/api', limiter as unknown as express.RequestHandler)
 
 // Parsing
 app.use(express.json({ limit: '10mb' }))
@@ -81,6 +81,15 @@ app.get('/health', (req, res) => {
     uptime: process.uptime(),
     environment: process.env.NODE_ENV || 'development',
     version: process.env.npm_package_version || '1.0.0'
+  })
+})
+
+// Root route
+app.get('/', (req, res) => {
+  res.json({
+    name: 'DTF Editor API',
+    version: process.env.npm_package_version || '1.0.0',
+    environment: process.env.NODE_ENV || 'development'
   })
 })
 

--- a/backend/src/routes/files.ts
+++ b/backend/src/routes/files.ts
@@ -39,7 +39,7 @@ const upload = multer({
  * POST /api/files/upload
  * Upload d'un ou plusieurs fichiers
  */
-router.post('/upload', upload.array('files', 10), async (req: Request, res: Response, next: NextFunction) => {
+router.post('/upload', upload.array('files', 10) as any, async (req: Request, res: Response, next: NextFunction) => {
   try {
     if (!req.files || !Array.isArray(req.files) || req.files.length === 0) {
       throw createApiError('Aucun fichier fourni', 400, 'NO_FILES_PROVIDED')
@@ -160,7 +160,7 @@ router.get('/:fileId/metadata', async (req: Request, res: Response, next: NextFu
  * POST /api/files/validate
  * Validation d'un fichier avant upload
  */
-router.post('/validate', upload.single('file'), async (req: Request, res: Response, next: NextFunction) => {
+router.post('/validate', upload.single('file') as any, async (req: Request, res: Response, next: NextFunction) => {
   try {
     if (!req.file) {
       throw createApiError('Aucun fichier fourni', 400, 'NO_FILE_PROVIDED')

--- a/package.json
+++ b/package.json
@@ -39,6 +39,10 @@
     "pdf",
     "typescript"
   ],
+  "resolutions": {
+    "@types/express": "4.17.21",
+    "@types/express-serve-static-core": "4.19.6"
+  },
   "author": "DTF Editor Team",
   "license": "MIT"
 }


### PR DESCRIPTION
Fixes TypeScript build errors by harmonizing Express typings and adds a root route to prevent 404s on deployment.

The build errors (TS2769) were caused by conflicting Express type versions (v4 and v5) being used simultaneously, leading to incompatible middleware types. Forcing Express v4 typings via `resolutions` and casting problematic middleware handlers resolves these. A new root route prevents 404 errors when the backend is accessed directly without the frontend.

---
<a href="https://cursor.com/background-agent?bcId=bc-14097ed0-1393-4d6d-9c7d-a58b56076cf8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-14097ed0-1393-4d6d-9c7d-a58b56076cf8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

