### PR TITLE
Fix index html serving error

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -7,8 +7,10 @@ services:
     region: frankfurt
     branch: main
     buildCommand: |
+      # Build shared module
+      cd shared && yarn install --frozen-lockfile && yarn build
       # Build du frontend
-      cd frontend && yarn install --frozen-lockfile && yarn build
+      cd ../frontend && yarn install --frozen-lockfile && yarn build
       # Build du backend
       cd ../backend && yarn install --frozen-lockfile && yarn build
       # Copier les fichiers du frontend dans le backend


### PR DESCRIPTION
Fix `index.html` not found error by correcting the build order and paths in `render.yaml`.

The `shared` module was not built before the `frontend` and `backend` modules, leading to missing dependencies and incorrect file copying for `index.html`. This PR ensures `shared` is built first and all paths are correctly resolved during the build process.

---
<a href="https://cursor.com/background-agent?bcId=bc-1ba396da-2f0c-46ed-86ec-8564cd08a14a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1ba396da-2f0c-46ed-86ec-8564cd08a14a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

