### PR TITLE
Corriger les erreurs CORS pour l'upload de fichiers

### DIFF
--- a/backend/src/public/dtf-editor.html
+++ b/backend/src/public/dtf-editor.html
@@ -861,7 +861,11 @@
                     }
 
                     // Uploader vers le backend
-                    const response = await fetch('/api/files/upload-raw', {
+                    const apiBaseUrl = (window.location.protocol === 'file:' || window.location.origin === 'null')
+                        ? 'http://localhost:3001'
+                        : window.location.origin;
+
+                    const response = await fetch(`${apiBaseUrl}/api/files/upload-raw`, {
                         method: 'POST',
                         body: formData
                     });

--- a/dtf-editor.html
+++ b/dtf-editor.html
@@ -861,7 +861,14 @@
                     }
 
                     // Uploader vers le backend
-                    const response = await fetch('/api/files/upload-raw', {
+                    // Si l'éditeur est ouvert via le système de fichiers (protocol "file:"),
+                    // window.location.origin vaut "null" et la requête relative échouerait.
+                    // On définit donc une URL de base par défaut (localhost:3001) pour ce cas.
+                    const apiBaseUrl = (window.location.protocol === 'file:' || window.location.origin === 'null')
+                        ? 'http://localhost:3001' // Fallback lors d'un lancement local
+                        : window.location.origin;
+
+                    const response = await fetch(`${apiBaseUrl}/api/files/upload-raw`, {
                         method: 'POST',
                         body: formData
                     });


### PR DESCRIPTION
Adjust API base URL for file uploads to resolve CORS errors when `dtf-editor.html` is opened via `file://` protocol.

When `dtf-editor.html` is accessed directly from the file system (e.g., `file:///C:/...`), the browser's security policy blocks `fetch` requests to relative paths (like `/api/...`) because the origin is `null`. This change introduces a fallback to `http://localhost:3001` for these scenarios, ensuring API calls succeed.

---
<a href="https://cursor.com/background-agent?bcId=bc-6f74be9a-e0ca-4083-bbde-2e9bd4215726">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6f74be9a-e0ca-4083-bbde-2e9bd4215726">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

